### PR TITLE
Add missing new metrics from HealthMetric enum

### DIFF
--- a/src/modules/health.c
+++ b/src/modules/health.c
@@ -6,11 +6,41 @@ static void health_handler(HealthEventType event, void *context) {
   main_window_update_ui();
 }
 
+static void test() {
+  const HealthMetric metric = HealthMetricWalkedDistanceMeters;
+  const HealthValue distance = health_service_sum_today(metric);
+
+  // Get the preferred measurement system
+  MeasurementSystem system = health_service_get_measurement_system_for_display(
+                                                                          metric);
+
+  // Format accordingly
+  static char s_buffer[32];
+  switch(system) {
+    case MeasurementSystemMetric:
+      APP_LOG(APP_LOG_LEVEL_INFO, "Walked %d meters", (int)distance);    
+      break;
+    case MeasurementSystemImperial: {
+      // Convert to imperial first
+      int feet = (int)((float)distance * 3.28F);
+      APP_LOG(APP_LOG_LEVEL_INFO, "Walked %d feet", (int)feet);
+    } break;
+    case MeasurementSystemUnknown:
+    default:
+      APP_LOG(APP_LOG_LEVEL_INFO, "MeasurementSystem unknown or does not apply");
+  }
+
+  // Display to user in correct units
+  // text_layer_set_text(s_some_layer, s_buffer);
+}
+
 void health_init() {
   s_health_available = health_service_events_subscribe(health_handler, NULL);
   if(!s_health_available) {
     APP_LOG(APP_LOG_LEVEL_ERROR, "Health not available!");
   }
+
+  test();
 }
 
 bool health_is_available() {

--- a/src/modules/health.c
+++ b/src/modules/health.c
@@ -6,41 +6,11 @@ static void health_handler(HealthEventType event, void *context) {
   main_window_update_ui();
 }
 
-static void test() {
-  const HealthMetric metric = HealthMetricWalkedDistanceMeters;
-  const HealthValue distance = health_service_sum_today(metric);
-
-  // Get the preferred measurement system
-  MeasurementSystem system = health_service_get_measurement_system_for_display(
-                                                                          metric);
-
-  // Format accordingly
-  static char s_buffer[32];
-  switch(system) {
-    case MeasurementSystemMetric:
-      APP_LOG(APP_LOG_LEVEL_INFO, "Walked %d meters", (int)distance);    
-      break;
-    case MeasurementSystemImperial: {
-      // Convert to imperial first
-      int feet = (int)((float)distance * 3.28F);
-      APP_LOG(APP_LOG_LEVEL_INFO, "Walked %d feet", (int)feet);
-    } break;
-    case MeasurementSystemUnknown:
-    default:
-      APP_LOG(APP_LOG_LEVEL_INFO, "MeasurementSystem unknown or does not apply");
-  }
-
-  // Display to user in correct units
-  // text_layer_set_text(s_some_layer, s_buffer);
-}
-
 void health_init() {
   s_health_available = health_service_events_subscribe(health_handler, NULL);
   if(!s_health_available) {
     APP_LOG(APP_LOG_LEVEL_ERROR, "Health not available!");
   }
-
-  test();
 }
 
 bool health_is_available() {

--- a/src/windows/main_window.c
+++ b/src/windows/main_window.c
@@ -1,26 +1,19 @@
 #include "main_window.h"
 
-typedef enum {
-  AppModeSteps = 0,
-  AppModeActiveTime,
-  AppModeDistance,
-  AppModeSleep,
-
-  AppModeMax
-} AppMode;
+#define MAX_METRICS HealthMetricActiveKCalories
 
 static Window *s_window;
 static TextLayer *s_value_layer, *s_label_layer;
 
-static AppMode s_mode;
+static HealthMetric s_metric;
 
 static void up_click_handler(ClickRecognizerRef recognizer, void *context) { 
-  s_mode -= (s_mode > 0) ? 1 : -(AppModeMax - 1);
+  s_metric -= (s_metric > 0) ? 1 : -(MAX_METRICS);
   main_window_update_ui();
 }
 
 static void down_click_handler(ClickRecognizerRef recognizer, void *context) { 
-  s_mode += (s_mode < AppModeMax - 1) ? 1 : -(AppModeMax - 1);
+  s_metric += (s_metric < MAX_METRICS) ? 1 : -(MAX_METRICS);
   main_window_update_ui();
 }
   
@@ -84,33 +77,44 @@ void main_window_update_ui() {
   if(health_is_available() && s_window) {
     static char s_value_buffer[8];
 
-    switch(s_mode) {
-      case AppModeSteps:
-        snprintf(s_value_buffer, sizeof(s_value_buffer), "%d", 
-                 health_get_metric_sum(HealthMetricStepCount));
+    snprintf(s_value_buffer, sizeof(s_value_buffer), "%d", 
+                                              health_get_metric_sum(s_metric));
+
+    switch(s_metric) {
+      case HealthMetricStepCount:
         text_layer_set_text(s_label_layer, "Steps taken today");
         window_set_background_color(s_window, GColorWindsorTan);
         break;
-      case AppModeActiveTime:
-        snprintf(s_value_buffer, sizeof(s_value_buffer), "%d", 
-                 health_get_metric_sum(HealthMetricActiveSeconds));
+      case HealthMetricActiveSeconds:
         text_layer_set_text(s_label_layer, "Seconds active today");
         window_set_background_color(s_window, GColorDarkGreen);
         break;
-      case AppModeDistance:
-        snprintf(s_value_buffer, sizeof(s_value_buffer), "%d", 
-                 health_get_metric_sum(HealthMetricWalkedDistanceMeters));
+      case HealthMetricWalkedDistanceMeters:
         text_layer_set_text(s_label_layer, "Meters travelled today");
         window_set_background_color(s_window, GColorJazzberryJam);
         break;
-      case AppModeSleep:
-        snprintf(s_value_buffer, sizeof(s_value_buffer), "%d", 
-                 health_get_metric_sum(HealthMetricSleepSeconds));
+      case HealthMetricSleepSeconds:
         text_layer_set_text(s_label_layer, "Seconds asleep today");
+        window_set_background_color(s_window, GColorBlueMoon);
+        break;
+      case HealthMetricSleepRestfulSeconds:
+        text_layer_set_text(s_label_layer, "Restful sleep today");
         window_set_background_color(s_window, GColorDukeBlue);
         break;
-      default: break;
+      case HealthMetricRestingKCalories:
+        text_layer_set_text(s_label_layer, "Resting kcal today");
+        window_set_background_color(s_window, GColorCadetBlue);
+        break;
+      case HealthMetricActiveKCalories:
+        text_layer_set_text(s_label_layer, "Active kcal today");
+        window_set_background_color(s_window, GColorMidnightGreen);
+        break;
+      default: 
+        text_layer_set_text(s_label_layer, "Unknown metric!");
+        window_set_background_color(s_window, GColorDarkGray);
+        break;
     }
+
     text_layer_set_text(s_value_layer, s_value_buffer);
   } else {
     window_set_background_color(s_window, GColorDarkCandyAppleRed);

--- a/src/windows/main_window.c
+++ b/src/windows/main_window.c
@@ -22,33 +22,32 @@ static void click_config_provider(void *context) {
   window_single_click_subscribe(BUTTON_ID_DOWN, down_click_handler);
 }
 
+static TextLayer* make_text_layer(int y_inset, char *font_key) {
+  Layer *window_layer = window_get_root_layer(s_window);
+  GRect bounds = layer_get_bounds(window_layer);
+
+  TextLayer *this = text_layer_create(grect_inset(bounds, 
+                                                GEdgeInsets(y_inset, 0, 0, 0)));
+  text_layer_set_text_alignment(this, GTextAlignmentCenter);
+  text_layer_set_text_color(this, GColorWhite);
+  text_layer_set_background_color(this, GColorClear);
+  text_layer_set_font(this, fonts_get_system_font(font_key));
+
+#if defined(PBL_ROUND)
+  text_layer_enable_screen_text_flow_and_paging(this, 5);
+#endif
+
+  return this;
+}
+
 static void window_load(Window *window) {
   Layer *window_layer = window_get_root_layer(window);
   GRect bounds = layer_get_bounds(window_layer);
 
-  s_value_layer = text_layer_create(grect_inset(bounds, 
-                                                GEdgeInsets(50, 0, 0, 0)));
-  text_layer_set_text_alignment(s_value_layer, GTextAlignmentCenter);
-  text_layer_set_text_color(s_value_layer, GColorWhite);
-  text_layer_set_background_color(s_value_layer, GColorClear);
-  text_layer_set_font(s_value_layer, 
-                      fonts_get_system_font(FONT_KEY_GOTHIC_28_BOLD));
+  s_value_layer = make_text_layer(50, FONT_KEY_GOTHIC_28_BOLD);
+  s_label_layer = make_text_layer(80, FONT_KEY_GOTHIC_24_BOLD);
   layer_add_child(window_layer, text_layer_get_layer(s_value_layer));
-
-  s_label_layer = text_layer_create(grect_inset(bounds, 
-                                                GEdgeInsets(80, 0, 0, 0)));
-  text_layer_set_text_alignment(s_label_layer, GTextAlignmentCenter);
-  text_layer_set_text_color(s_label_layer, GColorWhite);
-  text_layer_set_background_color(s_label_layer, GColorClear);
-  text_layer_set_font(s_label_layer, 
-                      fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD));
   layer_add_child(window_layer, text_layer_get_layer(s_label_layer));
-
-#if defined(PBL_ROUND)
-  text_layer_enable_screen_text_flow_and_paging(s_value_layer, 5);
-  text_layer_enable_screen_text_flow_and_paging(s_label_layer, 5);
-#endif
-
 }
 
 static void window_unload(Window *window) {
@@ -73,6 +72,11 @@ void main_window_push() {
   main_window_update_ui();
 }
 
+static void set_ui_values(char *label_text, GColor bg_color) {
+  text_layer_set_text(s_label_layer, label_text);
+  window_set_background_color(s_window, bg_color);
+}
+
 void main_window_update_ui() {
   if(health_is_available() && s_window) {
     static char s_value_buffer[8];
@@ -82,42 +86,33 @@ void main_window_update_ui() {
 
     switch(s_metric) {
       case HealthMetricStepCount:
-        text_layer_set_text(s_label_layer, "Steps taken today");
-        window_set_background_color(s_window, GColorWindsorTan);
+        set_ui_values("Steps taken today", GColorWindsorTan);
         break;
       case HealthMetricActiveSeconds:
-        text_layer_set_text(s_label_layer, "Seconds active today");
-        window_set_background_color(s_window, GColorDarkGreen);
+        set_ui_values("Seconds active today", GColorDarkGreen);
         break;
       case HealthMetricWalkedDistanceMeters:
-        text_layer_set_text(s_label_layer, "Meters travelled today");
-        window_set_background_color(s_window, GColorJazzberryJam);
+        set_ui_values("Meters travelled today", GColorJazzberryJam);
         break;
       case HealthMetricSleepSeconds:
-        text_layer_set_text(s_label_layer, "Seconds asleep today");
-        window_set_background_color(s_window, GColorBlueMoon);
+        set_ui_values("Seconds asleep today", GColorBlueMoon);
         break;
       case HealthMetricSleepRestfulSeconds:
-        text_layer_set_text(s_label_layer, "Restful sleep today");
-        window_set_background_color(s_window, GColorDukeBlue);
+        set_ui_values("Restful sleep today", GColorDukeBlue);
         break;
       case HealthMetricRestingKCalories:
-        text_layer_set_text(s_label_layer, "Resting kcal today");
-        window_set_background_color(s_window, GColorCadetBlue);
+        set_ui_values("Resting kcal today", GColorCadetBlue);
         break;
       case HealthMetricActiveKCalories:
-        text_layer_set_text(s_label_layer, "Active kcal today");
-        window_set_background_color(s_window, GColorMidnightGreen);
+        set_ui_values("Active kcal today", GColorMidnightGreen);
         break;
       default: 
-        text_layer_set_text(s_label_layer, "Unknown metric!");
-        window_set_background_color(s_window, GColorDarkGray);
         break;
     }
 
     text_layer_set_text(s_value_layer, s_value_buffer);
   } else {
-    window_set_background_color(s_window, GColorDarkCandyAppleRed);
     text_layer_set_text(s_value_layer, "Health not available!");
+    window_set_background_color(s_window, GColorDarkCandyAppleRed);
   }
 }

--- a/src/windows/main_window.c
+++ b/src/windows/main_window.c
@@ -112,7 +112,6 @@ void main_window_update_ui() {
 
     text_layer_set_text(s_value_layer, s_value_buffer);
   } else {
-    text_layer_set_text(s_value_layer, "Health not available!");
-    window_set_background_color(s_window, GColorDarkCandyAppleRed);
+    set_ui_values("Health not available!", GColorDarkCandyAppleRed);
   }
 }


### PR DESCRIPTION
Two new items were added in 3.10. AppMode was removed as redundant since the enum is a linear scale. 
